### PR TITLE
Fix home page layout and margins

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -25,6 +25,8 @@ body {
   background: var(--white);
   line-height: 1.6;
 }
+/* Prevent horizontal overflow on small screens */
+html, body { max-width: 100%; overflow-x: hidden; }
 img { max-width: 100%; height: auto; display: block; }
 a { color: inherit; text-decoration: none; }
 
@@ -33,7 +35,7 @@ a { color: inherit; text-decoration: none; }
   width: 100%;
   max-width: var(--container);
   margin: 0 auto;
-  padding: 0 20px;
+  padding: 0 16px;
 }
 
 /* Header */


### PR DESCRIPTION
Adjust home page container padding and add global overflow-x rule to prevent content from overflowing margins on small screens.

---
<a href="https://cursor.com/background-agent?bcId=bc-be04cc6f-0e27-419d-9c69-1d4acefe277c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-be04cc6f-0e27-419d-9c69-1d4acefe277c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

