### PR TITLE
Improve home page text contrast

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1419,6 +1419,17 @@ blockquote.card strong {
   margin-right: auto;
 }
 
+/* Ensure good contrast for section headers on dark backgrounds */
+.how-it-works .section-header h2,
+.testimonials .section-header h2 {
+  color: var(--white);
+}
+
+.how-it-works .section-subtitle,
+.testimonials .section-subtitle {
+  color: var(--gray-100);
+}
+
 /* How It Works Section */
 .how-it-works {
   padding: 80px 0;
@@ -2043,6 +2054,17 @@ blockquote.card strong {
   max-width: 600px;
   margin-left: auto;
   margin-right: auto;
+}
+
+/* Ensure good contrast for section headers on dark backgrounds */
+.how-it-works .section-header h2,
+.testimonials .section-header h2 {
+  color: var(--white);
+}
+
+.how-it-works .section-subtitle,
+.testimonials .section-subtitle {
+  color: var(--gray-100);
 }
 
 /* How It Works Section */


### PR DESCRIPTION
Improve text contrast for "How It Works" and "Testimonials" section headers to enhance readability, especially in dark mode.

The "How It Works" and "Testimonials" sections use a dark background (`#1e293b`) in dark mode. The default text colors (`--text` and `--text-light`) were designed for light backgrounds, resulting in poor contrast for the section titles and subtitles. This PR updates these elements to use lighter colors (`--white` and `--gray-100`) when on these dark backgrounds, ensuring better visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d7c6900-1a68-4344-951f-18ff495ef2dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d7c6900-1a68-4344-951f-18ff495ef2dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

